### PR TITLE
feat(api): enforce datasource list permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 # 👋 What is Nesis❓
 
 Nesis is an open-source enterprise knowledge discovery solution that connects to multitudes of datasources, collecting
+
+
 information and making it available in a conversation manner. Nesis leverages generative AI to aggregate document chunks
 collected from different documents in multiple formats such as pdf, docx, xlsx and turn them into meaning human-readable compositions. Allowing you to;
 
@@ -24,7 +26,7 @@ collected from different documents in multiple formats such as pdf, docx, xlsx a
 
 # Demo
 
-[![Nesis Demo](https://img.youtube.com/vi/TckJLflTVnk/0.jpg)](https://www.youtube.com/watch?v=TckJLflTVnk)
+https://github.com/ametnes/nesis/assets/86433807/64ea0ad8-5615-4111-8f6e-61ce7d3ad2fc
 
 ## 📜 Documentation
 Read the Nesis documentation [here](./docs/README.md)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 ---
 # 👋 What is Nesis❓
 
-## Overview
 Nesis is an open-source enterprise knowledge discovery solution that connects to multitudes of datasources, collecting
 information and making it available in a conversation manner. Nesis leverages generative AI to aggregate document chunks
 collected from different documents in multiple formats such as pdf, docx, xlsx and turn them into meaning human-readable compositions. Allowing you to;
@@ -22,6 +21,10 @@ collected from different documents in multiple formats such as pdf, docx, xlsx a
 1. Converse with your document via a simple chat interface.
 2. Conveniently view comparisons between documents.
 3. Summarise large documents.
+
+# Demo
+
+[![Nesis Demo](https://img.youtube.com/vi/TckJLflTVnk/0.jpg)](https://www.youtube.com/watch?v=TckJLflTVnk)
 
 ## 📜 Documentation
 Read the Nesis documentation [here](./docs/README.md)

--- a/nesis/api/core/document_loaders/minio.py
+++ b/nesis/api/core/document_loaders/minio.py
@@ -177,11 +177,14 @@ def _sync_document(
                 metadata=_metadata,
                 file_path=file_path,
             )
+            response_json = json.loads(response)
+
+        except ValueError:
+            _LOG.warning(f"File {file_path} ingestion failed", exc_info=True)
+            response_json = {}
         except UserWarning:
             _LOG.debug(f"File {file_path} is already processing")
             return
-
-        response_json = json.loads(response)
 
         save_document(
             document_id=item.etag,

--- a/nesis/api/tests/core/controllers/test_management_roles.py
+++ b/nesis/api/tests/core/controllers/test_management_roles.py
@@ -115,3 +115,93 @@ def test_create_role_as_user(client):
     assert 200 == roles_response.status_code, response.json
 
     print(json.dumps(response.json))
+
+
+def test_access_permitted_resources_as_user(client):
+    """
+    This tests that a user given read access to a specific datasource, will only be able to
+    list/read from that since datasource
+    :param client:
+    :return:
+    """
+
+    # Create an admin user
+    admin_session = tests.get_admin_session(app=client)
+
+    # Create a datasource
+    payload = {
+        "type": "minio",
+        "name": "finance6",
+        "connection": {
+            "user": "caikuodda",
+            "password": "some.password",
+            "host": "localhost",
+            "port": "5432",
+            "database": "initdb",
+        },
+    }
+
+    # Create finance6 datasource
+    response = client.post(
+        f"/v1/datasources",
+        headers=tests.get_header(token=admin_session["token"]),
+        data=json.dumps(payload),
+    )
+    assert 200 == response.status_code, response.json
+
+    # Create finance7 datasource
+    response = client.post(
+        f"/v1/datasources",
+        headers=tests.get_header(token=admin_session["token"]),
+        data=json.dumps({**payload, "name": "finance7"}),
+    )
+    assert 200 == response.status_code, response.json
+
+    # A role allowing access to the finance6 datasource
+    role = {
+        "name": f"document-manager{random.randint(3, 19)}",
+        "policy": {
+            "items": [
+                {"action": "read", "resource": "datasources/finance6"},
+            ]
+        },
+    }
+    response = client.post(
+        f"/v1/roles",
+        headers=tests.get_header(token=admin_session["token"]),
+        data=json.dumps(role),
+    )
+    assert 200 == response.status_code, response.json
+
+    # Admin creates a regular user assigning them access to the finance6 datasource
+    user_data = {
+        "name": "Test User",
+        "email": "another.user@domain.com",
+        "password": "password",
+        "roles": [response.json["id"]],
+        "enabled": True,
+    }
+
+    response = client.post(
+        f"/v1/users",
+        headers=tests.get_header(token=admin_session["token"]),
+        data=json.dumps(user_data),
+    )
+    assert 200 == response.status_code, response.json
+
+    user_session = client.post(
+        f"/v1/sessions",
+        headers=tests.get_header(),
+        data=json.dumps(user_data),
+    ).json
+    assert 200 == response.status_code, response.json
+
+    get_datasources = client.get(
+        f"/v1/datasources",
+        headers=tests.get_header(token=user_session["token"]),
+        data=json.dumps(user_data),
+    ).json
+
+    assert 1 == len(
+        get_datasources["items"]
+    ), f"Expected 1 datasource by received {len(get_datasources.json['items'])}"


### PR DESCRIPTION
This PR ensures that a a user can only get/list datasources that they have permission to.

Close #14 