### PR TITLE
build(rag): parameterize core build param

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,7 +19,7 @@ jobs:
   package_api:
     name: Package ${{ github.event.inputs.tag }} API
     runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
   package_frontend:
     name: Package ${{ github.event.inputs.tag }} frontend
     runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -71,8 +71,7 @@ jobs:
   package_rag_cpu:
     name: Package ${{ github.event.inputs.tag }}-${{ github.event.inputs.core }} RAG Engine
     runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
-    if: "${{ github.event.inputs.core == 'cpu' }}"
+    if: github.ref == 'refs/heads/22-parameterise-cuda-cpu-rag-images' && "${{ github.event.inputs.core == 'cpu' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -98,8 +97,7 @@ jobs:
   package_rag_cuda:
     name: Package ${{ github.event.inputs.tag }}-${{ github.event.inputs.core }} RAG Engine
     runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
-    if: "${{ github.event.inputs.core == 'cuda' }}"
+    if: github.ref == 'refs/heads/22-parameterise-cuda-cpu-rag-images' && "${{ github.event.inputs.core == 'cuda' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,6 +10,7 @@ on:
         description: 'Core'
         required: true
         default: cpu
+        type: choice
         options:
           - cpu
           - cuda

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,6 +10,9 @@ on:
         description: 'Core'
         required: true
         default: cpu
+        options:
+          - cpu
+          - cuda
 
 jobs:
   package_api:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -67,10 +67,11 @@ jobs:
             PROFILE=PROD
             NESIS_VERSION=${{ github.event.inputs.tag }}
 
-  package_rag:
+  package_rag_cpu:
     name: Package RAG Engine
     runs-on: ubuntu-latest
 #    if: github.ref == 'refs/heads/main'
+    if: "${{ github.event.inputs.tag == 'cpu' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -92,6 +93,23 @@ jobs:
           tags: ametnes/nesis:${{ github.event.inputs.tag }}-rag, ametnes/nesis:latest-rag
           build-args: |
             NESIS_VERSION=${{ github.event.inputs.tag }}
+
+  package_rag_cuda:
+    name: Package RAG Engine
+    runs-on: ubuntu-latest
+#    if: github.ref == 'refs/heads/main'
+    if: "${{ github.event.inputs.tag == 'cuda' }}"
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.dockerfile_branch }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Build and push core tagged RAG docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,7 +71,7 @@ jobs:
   package_rag_cpu:
     name: Package ${{ github.event.inputs.tag }}-${{ github.event.inputs.core }} RAG Engine
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/22-parameterise-cuda-cpu-rag-images' && "${{ github.event.inputs.core == 'cpu' }}"
+    if: github.ref == 'refs/heads/22-parameterise-cuda-cpu-rag-images' && github.event.inputs.core == 'cpu'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
   package_rag_cuda:
     name: Package ${{ github.event.inputs.tag }}-${{ github.event.inputs.core }} RAG Engine
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/22-parameterise-cuda-cpu-rag-images' && "${{ github.event.inputs.core == 'cuda' }}"
+    if: github.ref == 'refs/heads/22-parameterise-cuda-cpu-rag-images' && github.event.inputs.core == 'cuda'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,12 +6,16 @@ on:
       tag:
         description: 'Tag'
         required: true
+      core:
+        description: 'Core'
+        required: true
+        default: cpu
 
 jobs:
   package_api:
     name: Package API
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+#    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -35,7 +39,7 @@ jobs:
   package_frontend:
     name: Package Frontend
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+#    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -63,7 +67,7 @@ jobs:
   package_rag:
     name: Package RAG Engine
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+#    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -85,3 +89,14 @@ jobs:
           tags: ametnes/nesis:${{ github.event.inputs.tag }}-rag, ametnes/nesis:latest-rag
           build-args: |
             NESIS_VERSION=${{ github.event.inputs.tag }}
+
+      - name: Build and push core tagged RAG docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: ./nesis/rag/Dockerfile
+          tags: ametnes/nesis:${{ github.event.inputs.tag }}-rag-${{ github.event.inputs.core }}, ametnes/nesis:latest-rag-${{ github.event.inputs.core }}
+          build-args: |
+            NESIS_VERSION=${{ github.event.inputs.tag }}
+            CORE=${{ github.event.inputs.core }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,7 +71,7 @@ jobs:
   package_rag_cpu:
     name: Package ${{ github.event.inputs.tag }}-${{ github.event.inputs.core }} RAG Engine
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/22-parameterise-cuda-cpu-rag-images' && github.event.inputs.core == 'cpu'
+    if: github.ref == 'refs/heads/main' && github.event.inputs.core == 'cpu'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
   package_rag_cuda:
     name: Package ${{ github.event.inputs.tag }}-${{ github.event.inputs.core }} RAG Engine
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/22-parameterise-cuda-cpu-rag-images' && github.event.inputs.core == 'cuda'
+    if: github.ref == 'refs/heads/main' && github.event.inputs.core == 'cuda'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   package_api:
-    name: Package API
+    name: Package ${{ github.event.inputs.tag }} API
     runs-on: ubuntu-latest
 #    if: github.ref == 'refs/heads/main'
     steps:
@@ -41,7 +41,7 @@ jobs:
             NESIS_VERSION=${{ github.event.inputs.tag }}
 
   package_frontend:
-    name: Package Frontend
+    name: Package ${{ github.event.inputs.tag }} frontend
     runs-on: ubuntu-latest
 #    if: github.ref == 'refs/heads/main'
     steps:
@@ -69,7 +69,7 @@ jobs:
             NESIS_VERSION=${{ github.event.inputs.tag }}
 
   package_rag_cpu:
-    name: Package ${{ github.event.inputs.tag}} RAG Engine
+    name: Package ${{ github.event.inputs.tag }}-${{ github.event.inputs.core }} RAG Engine
     runs-on: ubuntu-latest
 #    if: github.ref == 'refs/heads/main'
     if: "${{ github.event.inputs.core == 'cpu' }}"
@@ -96,7 +96,7 @@ jobs:
             NESIS_VERSION=${{ github.event.inputs.tag }}
 
   package_rag_cuda:
-    name: Package ${{ github.event.inputs.tag}} RAG Engine
+    name: Package ${{ github.event.inputs.tag }}-${{ github.event.inputs.core }} RAG Engine
     runs-on: ubuntu-latest
 #    if: github.ref == 'refs/heads/main'
     if: "${{ github.event.inputs.core == 'cuda' }}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -69,10 +69,10 @@ jobs:
             NESIS_VERSION=${{ github.event.inputs.tag }}
 
   package_rag_cpu:
-    name: Package RAG Engine
+    name: Package ${{ github.event.inputs.tag}} RAG Engine
     runs-on: ubuntu-latest
 #    if: github.ref == 'refs/heads/main'
-    if: "${{ github.event.inputs.tag == 'cpu' }}"
+    if: "${{ github.event.inputs.core == 'cpu' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -96,10 +96,10 @@ jobs:
             NESIS_VERSION=${{ github.event.inputs.tag }}
 
   package_rag_cuda:
-    name: Package RAG Engine
+    name: Package ${{ github.event.inputs.tag}} RAG Engine
     runs-on: ubuntu-latest
 #    if: github.ref == 'refs/heads/main'
-    if: "${{ github.event.inputs.tag == 'cuda' }}"
+    if: "${{ github.event.inputs.core == 'cuda' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/nesis/rag/Dockerfile
+++ b/nesis/rag/Dockerfile
@@ -1,14 +1,24 @@
 FROM python:3.11-buster as build
+# Options are cpu and cuda
+ARG CORE=cpu
 COPY nesis/rag/requirements.txt /app/nesis/rag/requirements.txt
 COPY nesis/rag/requirements-huggingface.txt /app/nesis/rag/requirements-huggingface.txt
 COPY nesis/rag/requirements-torch-cpu-x86.txt /app/nesis/rag/requirements-torch-cpu-x86.txt
 
-RUN apt-get update \
-    && python -m venv /app/.venv \
-    && /app/.venv/bin/pip install -r /app/nesis/rag/requirements.txt \
-      -r /app/nesis/rag/requirements-torch-cpu-x86.txt -r /app/nesis/rag/requirements-huggingface.txt \
-      --default-timeout=1200
-
+RUN python -m venv /app/.venv
+RUN if [ "$CORE" = "cpu" ] ; \
+    then /app/.venv/bin/pip install \
+    -r /app/nesis/rag/requirements.txt \
+    -r /app/nesis/rag/requirements-torch-cpu-x86.txt \
+    -r /app/nesis/rag/requirements-huggingface.txt \
+    --default-timeout=1200 ; \
+    fi
+RUN if [ "$CORE" = "cuda" ] ; \
+    then /app/.venv/bin/pip install \
+    -r /app/nesis/rag/requirements.txt \
+    -r /app/nesis/rag/requirements-huggingface.txt \
+    --default-timeout=1200 ; \
+    fi
 
 
 ARG NESIS_VERSION


### PR DESCRIPTION
We introduce the ability to build for cpu and cuda cores. This is useful for local development where cuda may not be available. In this case, there is no need to build for cuda since cuda libraries can be demanding on bandwidth given their size.

Part of #22 

Tested with:
cpu build: https://github.com/ametnes/nesis/actions/runs/8773433435/job/24073500770
cuda build: https://github.com/ametnes/nesis/actions/runs/8773632133/job/24073937973