### PR TITLE
feat(api): add API server config block

### DIFF
--- a/nesis/api/core/config.py
+++ b/nesis/api/core/config.py
@@ -2,9 +2,13 @@ import os
 from tzlocal import get_localzone
 
 default = {
+    "server": {
+        "port": os.environ.get("NESIS_API_SERVER_PORT", "6000"),
+        "host": os.environ.get("NESIS_API_SERVER_HOST", "0.0.0.0"),
+    },
     "database": {
         "url": os.environ.get("NESIS_API_DATABASE_URL"),
-        "debug": False,
+        "debug": os.environ.get("NESIS_API_DATABASE_DEBUG", False),
         "create": False,
     },
     "tasks": {

--- a/nesis/api/core/config.py
+++ b/nesis/api/core/config.py
@@ -4,7 +4,7 @@ from tzlocal import get_localzone
 default = {
     "server": {
         "port": os.environ.get("NESIS_API_SERVER_PORT", "6000"),
-        "host": os.environ.get("NESIS_API_SERVER_HOST", "0.0.0.0"),
+        "address": os.environ.get("NESIS_API_SERVER_ADDRESS", "0.0.0.0"),
     },
     "database": {
         "url": os.environ.get("NESIS_API_DATABASE_URL"),

--- a/nesis/api/core/main.py
+++ b/nesis/api/core/main.py
@@ -59,8 +59,8 @@ def run_cloud(app, args, services):
         sys.exit(1)
 
     # Start the application
-    port = service_config.get("port", os.environ.get("NESIS_API_PORT")) or "6000"
-    host = service_config.get("host") or "0.0.0.0"
+    port = service_config["server"]["port"]
+    host = service_config["server"]["host"]
 
     http_server = WSGIServer((host, int(port)), cloud_ctrl.app)
 

--- a/nesis/api/core/main.py
+++ b/nesis/api/core/main.py
@@ -37,7 +37,7 @@ def run_cloud(app, args, services):
         config = {}
 
     config = util.merge(config, settings.default)
-    service_config = config.get("service") or {}
+    service_config = config.get("server") or {}
 
     # Initialize database
     try:
@@ -59,10 +59,10 @@ def run_cloud(app, args, services):
         sys.exit(1)
 
     # Start the application
-    port = service_config["server"]["port"]
-    host = service_config["server"]["host"]
+    port = service_config["port"]
+    address = service_config["address"]
 
-    http_server = WSGIServer((host, int(port)), cloud_ctrl.app)
+    http_server = WSGIServer((address, int(port)), cloud_ctrl.app)
 
     _LOG.info("Starting server...")
     http_server.serve_forever()


### PR DESCRIPTION
We introduce an explicit server config block and environment variables for;
1. API server port `NESIS_API_SERVER_PORT`
2. API server listen address `NESIS_API_SERVER_ADDRESS`

This is to allow easier configuration during deployment via environment variables of config yaml.

Part of #25 