### PR TITLE
feat(frontend)(api): add sharepoint datasoure

### DIFF
--- a/docs/src/dev-guide/local.md
+++ b/docs/src/dev-guide/local.md
@@ -110,16 +110,12 @@ Install dependencies
 pip install -r nesis/api/requirements.txt
 ```
 
-Running the database migration
-```bash
-alembic -x "url=postgresql://postgres:password@127.0.0.1:65432/nesis" --config nesis/api/alembic.ini upgrade head
-```
-
 Start the service
 ```bash
 export NESIS_ADMIN_EMAIL="some.email@domain.com"
 export NESIS_ADMIN_PASSWORD="password"
-python nesis/rag/api/main.py
+export NESIS_API_DATABASE_CREATE="true"
+python nesis/api/core/main.py
 ```
 
 #### Start the frontend

--- a/nesis/api/core/config.py
+++ b/nesis/api/core/config.py
@@ -9,7 +9,7 @@ default = {
     "database": {
         "url": os.environ.get("NESIS_API_DATABASE_URL"),
         "debug": os.environ.get("NESIS_API_DATABASE_DEBUG", False),
-        "create": False,
+        "create": bool(os.environ.get("NESIS_API_DATABASE_CREATE", "false")),
     },
     "tasks": {
         "job": {

--- a/nesis/api/core/document_loaders/sharepoint.py
+++ b/nesis/api/core/document_loaders/sharepoint.py
@@ -26,8 +26,6 @@ from nesis.api.core.util.dateutil import strptime
 
 _LOG = logging.getLogger(__name__)
 
-_sharepoint_context = None
-
 
 def fetch_documents(
     connection: Dict[str, str],
@@ -36,7 +34,6 @@ def fetch_documents(
     metadata: Dict[str, Any],
     cache_client: memcache.Client,
 ) -> None:
-    global _sharepoint_context
     try:
 
         site_url = connection.get("endpoint")
@@ -45,13 +42,12 @@ def fetch_documents(
         thumbprint = connection.get("thumbprint")
         cert_path = connection.get("certificate")
 
-        if _sharepoint_context is None:
-            _sharepoint_context = ClientContext(site_url).with_client_certificate(
-                tenant=tenant,
-                client_id=client_id,
-                thumbprint=thumbprint,
-                cert_path=cert_path,
-            )
+        _sharepoint_context = ClientContext(site_url).with_client_certificate(
+            tenant=tenant,
+            client_id=client_id,
+            thumbprint=thumbprint,
+            cert_path=cert_path,
+        )
 
         _sync_sharepoint_documents(
             sp_context=_sharepoint_context,

--- a/nesis/api/core/document_loaders/sharepoint.py
+++ b/nesis/api/core/document_loaders/sharepoint.py
@@ -1,13 +1,15 @@
 import json
-import os
 import pathlib
-import uuid
+import tempfile
 from typing import Dict, Any
+from urllib.parse import urlparse
+
+import memcache
 
 from office365.sharepoint.client_context import ClientContext
 from office365.runtime.client_request_exception import ClientRequestException
 
-import nesis.api.core.util.http as http
+from nesis.api.core.util import http, clean_control, isblank
 import logging
 from nesis.api.core.models.entities import Document
 from nesis.api.core.services.util import (
@@ -15,6 +17,8 @@ from nesis.api.core.services.util import (
     get_document,
     delete_document,
     get_documents,
+    un_ingest_file,
+    ingest_file,
 )
 from nesis.api.core.util import isblank
 from nesis.api.core.util.constants import DEFAULT_DATETIME_FORMAT
@@ -25,158 +29,261 @@ _LOG = logging.getLogger(__name__)
 _sharepoint_context = None
 
 
-def fetch_documents(**kwargs) -> None:
-    try:
-        rag_endpoint = kwargs["rag_endpoint"]
-        connection = kwargs["connection"]
-
-        _sync_sharepoint_documents(
-            **kwargs, connection=connection, rag_endpoint=rag_endpoint
-        )
-        _unsync_sharepoint_documents(
-            **kwargs, connection=connection, rag_endpoint=rag_endpoint
-        )
-    except:
-        _LOG.exception("Error fetching sharepoint documents")
-
-
-def _sync_sharepoint_documents(**kwargs):
+def fetch_documents(
+    connection: Dict[str, str],
+    rag_endpoint: str,
+    http_client: http.HttpClient,
+    metadata: Dict[str, Any],
+    cache_client: memcache.Client,
+) -> None:
     global _sharepoint_context
-    config = kwargs["config"]["tasks"]["fetch_documents"].get("config") or {}
-    http_client: http.HttpClient = kwargs["http_client"]
-    doc_store_connection = kwargs["connection"]
     try:
-        site_url = doc_store_connection.get("site_url")
-        client_id = doc_store_connection.get("client_id")
-        client_secret = doc_store_connection.get("secret_key")
+
+        site_url = connection.get("endpoint")
+        client_id = connection.get("client_id")
+        tenant = connection.get("tenant")
+        thumbprint = connection.get("thumbprint")
+        cert_path = connection.get("certificate")
 
         if _sharepoint_context is None:
-            _sharepoint_context = ClientContext(site_url).with_client_credentials(
-                client_id=client_id, client_secret=client_secret
+            _sharepoint_context = ClientContext(site_url).with_client_certificate(
+                tenant=tenant,
+                client_id=client_id,
+                thumbprint=thumbprint,
+                cert_path=cert_path,
             )
 
-        file_locations = doc_store_connection.get("file_locations")
+        _sync_sharepoint_documents(
+            sp_context=_sharepoint_context,
+            connection=connection,
+            rag_endpoint=rag_endpoint,
+            http_client=http_client,
+            metadata=metadata,
+            cache_client=cache_client,
+        )
+        _unsync_sharepoint_documents(
+            sp_context=_sharepoint_context,
+            connection=connection,
+            rag_endpoint=rag_endpoint,
+            http_client=http_client,
+        )
+    except Exception as ex:
+        _LOG.exception(f"Error fetching sharepoint documents - {ex}")
 
-        rag_endpoint = kwargs["rag_endpoint"]
 
-        location_names = file_locations.split(",")
-        work_dir = f"/tmp/{uuid.uuid4()}"
-        pathlib.Path(work_dir).mkdir(parents=True)
-
+def _sync_sharepoint_documents(
+    sp_context, connection, rag_endpoint, http_client, metadata, cache_client
+):
+    try:
         _LOG.info(f"Initializing sharepoint syncing to endpoint {rag_endpoint}")
 
-        # Sharepoint stores documents in different ways, in folders and there is a concept of lists Most document
-        # libraries are stores as lists, thus we can safely assume that the locations provided in the settings are
-        # Sharepoint document libraries (lists) We use this assumption to access the respective files
+        if sp_context is None:
+            raise Exception(
+                "Sharepoint context is null, cannot proceed with document processing."
+            )
 
-        for location_name in location_names:
-            try:
-                folder = _sharepoint_context.web.lists.get_by_title(
-                    location_name
-                ).root_folder
-                files = folder.get_files(recursive=True).execute_query()
-            except:
-                _LOG.warn(f"Failed to list files in file location {location_name}")
+        # Data objects allow us to specify folder names
+        sharepoint_folders = connection.get("dataobjects")
+        if sharepoint_folders is None:
+            _LOG.warning("Sharepoint folders are specified, so I can't do much")
+
+        sp_folders = sharepoint_folders.split(",")
+
+        root_folder = sp_context.web.default_document_library().root_folder
+
+        for folder_name in sp_folders:
+            sharepoint_folder = root_folder.folders.get_by_path(folder_name)
+
+            if sharepoint_folder is None:
+                _LOG.warning(
+                    f"Cannot retrieve Sharepoint folder {sharepoint_folder} proceeding to process other folders"
+                )
                 continue
-            for file in files:
-                file_path = f"{work_dir}/{location_name}"
-                try:
-                    _LOG.info(
-                        f"Starting syncing file {file.name} in location {location_name}"
-                    )
-                    downloaded_file_name = os.path.join(file_path, file.name)
-                    # How can we refine this for efficiency
-                    with open(downloaded_file_name, "wb") as local_file:
-                        file.download(local_file).execute_query()
 
-                    document: Document = get_document(document_id=file.unique_id)
-                    if document:
-                        store_metadata = document.store_metadata
-                        if store_metadata and store_metadata.get("last_modified"):
-                            if not strptime(
-                                date_string=store_metadata["last_modified"]
-                            ).replace(tzinfo=None) < file.last_modified.replace(
-                                tzinfo=None
-                            ).replace(
-                                microsecond=0
-                            ):
-                                _LOG.debug(
-                                    f"Skipping file {file.name} already up to date"
-                                )
-                                continue
-                            rag_metadata: dict = document.rag_metadata
-                            if rag_metadata is None:
-                                continue
-                            for document_data in rag_metadata.get("data") or []:
-                                try:
-                                    http_client.delete(
-                                        url=f"{rag_endpoint}/v1/ingest/{document_data['doc_id']}"
-                                    )
-                                except:
-                                    _LOG.warn(
-                                        f"Failed to delete document {document_data['doc_id']}"
-                                    )
+            _process_folder_files(
+                sharepoint_folder,
+                connection=connection,
+                rag_endpoint=rag_endpoint,
+                http_client=http_client,
+                metadata=metadata,
+                cache_client=cache_client,
+            )
 
-                            try:
-                                delete_document(document_id=file.unique_id)
-                            except:
-                                _LOG.warn(
-                                    f"Failed to delete file {file.name}'s record. Continuing anyway..."
-                                )
-
-                    response = http_client.upload(
-                        url=f"{rag_endpoint}/v1/ingest",
-                        filepath=downloaded_file_name,
-                        field="file",
-                    )
-                    response_json = json.loads(response)
-
-                    save_document(
-                        document_id=file.unique_id,
-                        filename=file.name,
-                        base_uri=site_url,
-                        rag_metadata=response_json,
-                        store_metadata={
-                            "file_url": f"{location_name}/{file.name}",
-                            "file_name": file.name,
-                            "etag": file.unique_id,
-                            "size": file.length,
-                            "author": file.author,
-                            "last_modified": file.time_last_modified.strftime(
-                                DEFAULT_DATETIME_FORMAT
-                            ),
-                            "version_id": f"{file.major_version}-{file.minor_version}",
-                        },
-                    )
-
-                    _LOG.info(
-                        f"Done syncing file {file.name} in location {location_name}"
-                    )
-                except Exception as ex:
-                    _LOG.warn(
-                        f"Error when getting and ingesting file {file.name} - {ex}"
-                    )
-
+            # Recursively get all the child folders
+            _child_folders_recursive = sharepoint_folder.get_folders(
+                True
+            ).execute_query()
+            for _child_folder in _child_folders_recursive:
+                _process_folder_files(
+                    _child_folder,
+                    connection=connection,
+                    rag_endpoint=rag_endpoint,
+                    http_client=http_client,
+                    metadata=metadata,
+                    cache_client=cache_client,
+                )
         _LOG.info(f"Completed syncing to endpoint {rag_endpoint}")
 
-    except:
-        _LOG.warn("Error fetching and updating documents", exc_info=True)
+    except Exception as file_ex:
+        _LOG.exception(
+            f"Error fetching and updating documents - Error: {file_ex}", exc_info=True
+        )
 
 
-def _unsync_sharepoint_documents(**kwargs):
-    global _sharepoint_context
-    http_client: http.HttpClient = kwargs["http_client"]
-    doc_store_connection = kwargs["connection"]
-    rag_endpoint = kwargs["rag_endpoint"]
+def _process_file(file, connection, rag_endpoint, http_client, metadata, cache_client):
+    site_url = connection.get("endpoint")
+    parsed_site_url = urlparse(site_url)
+    site_root_url = "{uri.scheme}://{uri.netloc}".format(uri=parsed_site_url)
+    self_link = f"{site_root_url}{file.serverRelativeUrl}"
+    _metadata = {
+        **(metadata or {}),
+        "file_name": file.name,
+        "self_link": self_link,
+    }
+
+    """
+    We use memcache's add functionality to implement a shared lock to allow for multiple instances
+    operating 
+    """
+    _lock_key = clean_control(f"{__name__}/locks/{self_link}")
+    if cache_client.add(key=_lock_key, val=_lock_key, time=30 * 60):
+        try:
+            _sync_document(
+                connection=connection,
+                rag_endpoint=rag_endpoint,
+                http_client=http_client,
+                metadata=_metadata,
+                file=file,
+            )
+        finally:
+            cache_client.delete(_lock_key)
+    else:
+        _LOG.info(f"Document {self_link} is already processing")
+
+
+def _process_folder_files(
+    folder, connection, rag_endpoint, http_client, metadata, cache_client
+):
+    # process files in folder
+    _files = folder.get_files(False).execute_query()
+    for file in _files:
+        _process_file(
+            file=file,
+            connection=connection,
+            rag_endpoint=rag_endpoint,
+            http_client=http_client,
+            metadata=metadata,
+            cache_client=cache_client,
+        )
+
+
+def _sync_document(
+    connection: dict,
+    rag_endpoint: str,
+    http_client: http.HttpClient,
+    metadata: dict,
+    file,
+):
+    site_url = connection["endpoint"]
+    _metadata = metadata
+
+    with tempfile.NamedTemporaryFile(
+        dir=tempfile.gettempdir(),
+    ) as tmp:
+        key_parts = file.serverRelativeUrl.split("/")
+
+        path_to_tmp = f"{str(pathlib.Path(tmp.name).absolute())}-{key_parts[-1]}"
+
+        try:
+            _LOG.info(
+                f"Starting syncing file {file.name} from {file.serverRelativeUrl}"
+            )
+            # Write item to file
+            downloaded_file_name = path_to_tmp  # os.path.join(path_to_tmp, file.name)
+            # How can we refine this for efficiency
+            with open(downloaded_file_name, "wb") as local_file:
+                file.download(local_file).execute_query()
+
+            document: Document = get_document(document_id=file.unique_id)
+            if document and document.base_uri == site_url:
+                store_metadata = document.store_metadata
+                if store_metadata and store_metadata.get("last_modified"):
+                    last_modified = store_metadata["last_modified"]
+                    if (
+                        not strptime(date_string=last_modified).replace(tzinfo=None)
+                        < file.time_last_modified
+                    ):
+                        _LOG.debug(
+                            f"Skipping sharepoint document {file.name} already up to date"
+                        )
+                        return
+                    rag_metadata: dict = document.rag_metadata
+                    if rag_metadata is None:
+                        return
+                    for document_data in rag_metadata.get("data") or []:
+                        try:
+                            un_ingest_file(
+                                http_client=http_client,
+                                endpoint=rag_endpoint,
+                                doc_id=document_data["doc_id"],
+                            )
+                        except:
+                            _LOG.warning(
+                                f"Failed to delete document {document_data['doc_id']}"
+                            )
+                    try:
+                        delete_document(document_id=document.id)
+                    except:
+                        _LOG.warning(
+                            f"Failed to delete document {file.name}'s record. Continuing anyway..."
+                        )
+            try:
+                response = ingest_file(
+                    http_client=http_client,
+                    endpoint=rag_endpoint,
+                    metadata=_metadata,
+                    file_path=downloaded_file_name,
+                )
+                response_json = json.loads(response)
+
+            except ValueError:
+                _LOG.warning(
+                    f"File {downloaded_file_name} ingestion failed", exc_info=True
+                )
+                response_json = {}
+            except UserWarning:
+                _LOG.debug(f"File {downloaded_file_name} is already processing")
+                return
+
+            save_document(
+                document_id=file.unique_id,
+                filename=file.name,
+                base_uri=site_url,
+                rag_metadata=response_json,
+                store_metadata={
+                    "file_name": file.name,
+                    "file_url": file.serverRelativeUrl,
+                    "etag": file.unique_id,
+                    "size": file.length,
+                    "author": file.author,
+                    "last_modified": file.time_last_modified.strftime(
+                        DEFAULT_DATETIME_FORMAT
+                    ),
+                },
+            )
+            _LOG.info(f"Done syncing object {file.name} in at {file.serverRelativeUrl}")
+        except Exception as ex:
+            _LOG.warning(f"Error when getting and ingesting file {file.name} - {ex}")
+
+
+def _unsync_sharepoint_documents(sp_context, http_client, rag_endpoint, connection):
 
     try:
-        site_url = doc_store_connection.get("site_url")
-        client_id = doc_store_connection.get("client_id")
-        client_secret = doc_store_connection.get("secret_key")
+        site_url = connection.get("endpoint")
 
-        if _sharepoint_context is None:
-            _sharepoint_context = ClientContext(site_url).with_client_credentials(
-                client_id=client_id, client_secret=client_secret
+        if sp_context is None:
+            raise Exception(
+                "Sharepoint context is null, cannot proceed with document processing."
             )
 
         documents = get_documents(base_uri=site_url)
@@ -186,7 +293,7 @@ def _unsync_sharepoint_documents(**kwargs):
             file_url = store_metadata["file_url"]
             try:
                 # Check that the file still exists on the sharepoint server
-                _sharepoint_context.web.get_file_by_server_relative_url(
+                sp_context.web.get_file_by_server_relative_url(
                     file_url
                 ).get().execute_query()
             except ClientRequestException as e:
@@ -195,7 +302,7 @@ def _unsync_sharepoint_documents(**kwargs):
                     for document_data in rag_metadata.get("data") or []:
                         try:
                             http_client.delete(
-                                url=f"{rag_endpoint}/v1/ingest/{document_data['doc_id']}"
+                                url=f"{rag_endpoint}/v1/ingest/documents/{document_data['doc_id']}"
                             )
                         except:
                             _LOG.warn(
@@ -203,13 +310,23 @@ def _unsync_sharepoint_documents(**kwargs):
                             )
                     _LOG.info(f"Deleting document {document.filename}")
                     delete_document(document_id=document.id)
-
+            except Exception as ex:
+                _LOG.warning(
+                    f"Failed to retrieve file {file_url} from sharepoint - {ex}"
+                )
     except:
         _LOG.warning("Error fetching and updating documents", exc_info=True)
 
 
 def validate_connection_info(connection: Dict[str, Any]) -> Dict[str, Any]:
-    _valid_keys = ["endpoint", "client_id", "thumbprint", "certificate", "dataobjects"]
+    _valid_keys = [
+        "endpoint",
+        "tenant",
+        "client_id",
+        "thumbprint",
+        "certificate",
+        "dataobjects",
+    ]
     assert not isblank(connection.get("endpoint")), "A site url must be supplied"
     assert not isblank(connection.get("client_id")), "A client_id must be supplied"
     assert not isblank(connection.get("thumbprint")), "A thumbprint must be supplied"

--- a/nesis/api/core/document_loaders/sharepoint.py
+++ b/nesis/api/core/document_loaders/sharepoint.py
@@ -71,22 +71,6 @@ def fetch_documents(
         _LOG.exception(f"Error fetching sharepoint documents - {ex}")
 
 
-def _get_temp_certificate_path(connection) -> str:
-    cert_path = ""
-    certificate_details = connection["certificate"]
-    try:
-        with tempfile.NamedTemporaryFile(
-            dir=tempfile.gettempdir(), delete_on_close=False
-        ) as tmp:
-            cert_path = f"{str(pathlib.Path(tmp.name).absolute())}-{uuid.uuid4()}.key"
-
-            with open(cert_path, "w") as svc_file:
-                svc_file.write(certificate_details)
-    except Exception as ex:
-        _LOG.error(f"Failed to generate certificate path - {ex}")
-    return cert_path
-
-
 def _sync_sharepoint_documents(
     sp_context, connection, rag_endpoint, http_client, metadata, cache_client
 ):
@@ -337,7 +321,7 @@ def _unsync_sharepoint_documents(sp_context, http_client, rag_endpoint, connecti
 def validate_connection_info(connection: Dict[str, Any]) -> Dict[str, Any]:
     _valid_keys = [
         "endpoint",
-        "tenant",
+        "tenant_id",
         "client_id",
         "thumbprint",
         "certificate",
@@ -345,6 +329,7 @@ def validate_connection_info(connection: Dict[str, Any]) -> Dict[str, Any]:
     ]
     assert not isblank(connection.get("endpoint")), "A site url must be supplied"
     assert not isblank(connection.get("client_id")), "A client_id must be supplied"
+    assert not isblank(connection.get("tenant_id")), "A client_id must be supplied"
     assert not isblank(connection.get("thumbprint")), "A thumbprint must be supplied"
     assert not isblank(
         connection.get("certificate")

--- a/nesis/api/core/tasks/document_management.py
+++ b/nesis/api/core/tasks/document_management.py
@@ -6,7 +6,7 @@ import nesis.api.core.document_loaders.google_drive as google_drive
 import nesis.api.core.document_loaders.minio as s3_documents
 import nesis.api.core.document_loaders.s3 as s3
 import nesis.api.core.document_loaders.samba as samba
-import nesis.api.core.document_loaders.sharepoint as sharepoint_documents
+import nesis.api.core.document_loaders.sharepoint as sharepoint
 from nesis.api.core.models.entities import Datasource, DatasourceType
 from nesis.api.core.services.datasources import DatasourceService
 from nesis.api.core.util import http
@@ -45,10 +45,11 @@ def ingest_datasource(**kwargs) -> None:
                 metadata={"datasource": datasource.name},
             )
         case DatasourceType.SHAREPOINT:
-            sharepoint_documents.fetch_documents(
-                **kwargs,
+            sharepoint.fetch_documents(
                 connection=datasource.connection,
                 rag_endpoint=rag_endpoint,
+                http_client=http_client,
+                cache_client=cache_client,
                 metadata={"datasource": datasource.name},
             )
         case DatasourceType.GOOGLE_DRIVE:

--- a/nesis/api/tests/core/document_loaders/conftest.py
+++ b/nesis/api/tests/core/document_loaders/conftest.py
@@ -1,0 +1,33 @@
+import os
+import unittest.mock as mock
+
+import pytest
+from sqlalchemy.orm.session import Session
+
+import nesis.api.core.services as services
+from nesis.api import tests
+from nesis.api.core.models import DBSession
+from nesis.api.core.models import initialize_engine
+
+
+@pytest.fixture
+def session() -> None:
+    return DBSession()
+
+
+@pytest.fixture
+def cache() -> mock.MagicMock:
+    return mock.MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def configure() -> None:
+    os.environ["OPENAI_API_BASE"] = "http://localhost:8080/v1"
+
+    initialize_engine(tests.config)
+    session: Session = DBSession()
+    tests.clear_database(session)
+
+    os.environ["OPENAI_API_KEY"] = "some.api.key"
+
+    services.init_services(tests.config)

--- a/nesis/api/tests/core/document_loaders/test_sharepoint.py
+++ b/nesis/api/tests/core/document_loaders/test_sharepoint.py
@@ -1,0 +1,370 @@
+import json
+import os
+import datetime
+import uuid
+
+import unittest as ut
+import unittest.mock as mock
+
+from sqlalchemy.orm.session import Session
+
+import nesis.api.core.document_loaders.sharepoint as sharepoint
+from nesis.api import tests
+from nesis.api.core.models import DBSession
+from nesis.api.core.models import initialize_engine
+import nesis.api.core.services as services
+from nesis.api.core.models.entities import (
+    Datasource,
+    DatasourceType,
+    DatasourceStatus,
+    Document,
+)
+
+
+@mock.patch("nesis.api.core.document_loaders.sharepoint.ClientContext")
+def test_sync_sharepoint_documents(
+    client_context: mock.MagicMock, cache: mock.MagicMock, session: Session
+) -> None:
+    data = {
+        "name": "sharepoint documents",
+        "engine": "sharepoint",
+        "connection": {
+            "endpoint": "https://ametnes.sharepoint.com/sites/nesis-test/",
+            "client_id": "<sharepoint_app_client_id>",
+            "tenant": "<sharepoint_app_tenant_id>",
+            "thumbprint": "<sharepoint_app_cert_thumbprint>",
+            "certificate": "path_to_private_cert_keyfile",
+            "dataobjects": "Books",
+        },
+    }
+
+    datasource = Datasource(
+        name=data["name"],
+        connection=data["connection"],
+        source_type=DatasourceType.SHAREPOINT,
+        status=DatasourceStatus.ONLINE,
+    )
+
+    session.add(datasource)
+    session.commit()
+
+    sp_client_context = mock.MagicMock()
+    root_folder = mock.MagicMock()
+
+    file_mock = mock.MagicMock()
+    _folders = mock.MagicMock()
+
+    client_context().with_client_certificate.return_value = sp_client_context
+
+    sp_client_context.web.default_document_library.return_value.root_folder = (
+        root_folder
+    )
+
+    type(file_mock).name = mock.PropertyMock(return_value="some_file.pdf")
+    type(file_mock).serverRelativeUrl = mock.PropertyMock(
+        return_value=r"/sites/nesit-test/Shared Documents/some_file.pdf"
+    )
+    type(file_mock).unique_id = mock.PropertyMock(return_value="123123-123131-1313")
+    type(file_mock).time_last_modified = mock.PropertyMock(return_value=datetime.time())
+    type(file_mock).length = mock.PropertyMock(return_value=1023)
+    type(file_mock).author = mock.PropertyMock(return_value="file author")
+
+    root_folder.folders.get_by_path.return_value = _folders
+    _folders.get_files.return_value.execute_query.return_value = [file_mock]
+
+    file_download = mock.MagicMock()
+    file_mock.download.return_value.execute_query.return_value = file_download
+
+    http_client = mock.MagicMock()
+    http_client.upload.return_value = json.dumps({})
+
+    sharepoint.fetch_documents(
+        connection=data["connection"],
+        http_client=http_client,
+        metadata={"datasource": "documents"},
+        rag_endpoint="http://localhost:8080",
+        cache_client=cache,
+    )
+
+    _, upload_kwargs = http_client.upload.call_args_list[0]
+    url = upload_kwargs["url"]
+    file_path = upload_kwargs["filepath"]
+    metadata = upload_kwargs["metadata"]
+    field = upload_kwargs["field"]
+
+    assert url == f"http://localhost:8080/v1/ingest/files"
+    assert file_path.endswith("some_file.pdf")
+    assert field == "file"
+    ut.TestCase().assertDictEqual(
+        metadata,
+        {
+            "datasource": "documents",
+            "file_name": "some_file.pdf",
+            "self_link": r"https://ametnes.sharepoint.com/sites/nesit-test/Shared Documents/some_file.pdf",
+        },
+    )
+
+
+@mock.patch("nesis.api.core.document_loaders.sharepoint.ClientContext")
+def test_sync_updated_sharepoint_documents(
+    sharepoint_context: mock.MagicMock, cache: mock.MagicMock, session: Session
+) -> None:
+    """
+    Test updating documents if they have been updated on Sharepoint
+    """
+
+    data = {
+        "name": "sharepoint documents",
+        "engine": "sharepoint",
+        "connection": {
+            "endpoint": "https://ametnes.sharepoint.com/sites/nesis-test/",
+            "client_id": "<sharepoint_app_client_id>",
+            "tenant": "<sharepoint_app_tenant_id>",
+            "thumbprint": "<sharepoint_app_cert_thumbprint>",
+            "certificate": "path_to_private_cert_keyfile",
+            "dataobjects": "Books",
+        },
+    }
+
+    document = Document(
+        base_uri="https://ametnes.sharepoint.com/sites/nesis-test/",
+        document_id="edu323-23423-23frs-234232",
+        filename="sharepoint_file.pdf",
+        rag_metadata={"data": [{"doc_id": str(uuid.uuid4())}]},
+        store_metadata={
+            "file_name": "sharepoint_file.pdf",
+            "file_url": "/sites/nesit-test/Shared Documents/sharepoint_file.pdf",
+            "etag": "edu323-23423-23frs-234232",
+            "size": 1023,
+            "author": "author_name",
+            "last_modified": "2024-01-10 06:40:07",
+        },
+    )
+
+    session.add(document)
+    session.commit()
+
+    sp_client_context = mock.MagicMock()
+    root_folder = mock.MagicMock()
+
+    file_mock = mock.MagicMock()
+    _folders = mock.MagicMock()
+
+    sharepoint_context().with_client_certificate.return_value = sp_client_context
+
+    sp_client_context.web.default_document_library.return_value.root_folder = (
+        root_folder
+    )
+
+    type(file_mock).name = mock.PropertyMock(return_value="sharepoint_file.pdf")
+    type(file_mock).serverRelativeUrl = mock.PropertyMock(
+        return_value=r"/sites/nesit-test/Shared Documents/sharepoint_file.pdf"
+    )
+    type(file_mock).unique_id = mock.PropertyMock(
+        return_value="edu323-23423-23frs-234232"
+    )
+    type(file_mock).time_last_modified = mock.PropertyMock(
+        return_value=datetime.datetime.strptime(
+            "2024-04-10 06:40:07", "%Y-%m-%d %H:%M:%S"
+        )
+    )
+    type(file_mock).length = mock.PropertyMock(return_value=2023)
+    type(file_mock).author = mock.PropertyMock(return_value="file author")
+
+    root_folder.folders.get_by_path.return_value = _folders
+    _folders.get_files.return_value.execute_query.return_value = [file_mock]
+
+    file_download = mock.MagicMock()
+    file_mock.download.return_value.execute_query.return_value = file_download
+
+    http_client = mock.MagicMock()
+    http_client.upload.return_value = json.dumps({})
+
+    sharepoint.fetch_documents(
+        connection=data["connection"],
+        http_client=http_client,
+        metadata={"datasource": "documents"},
+        rag_endpoint="http://localhost:8080",
+        cache_client=cache,
+    )
+
+    # The document would be deleted from the rag engine
+    _, upload_kwargs = http_client.delete.call_args_list[0]
+    url = upload_kwargs["url"]
+
+    assert (
+        url
+        == f"http://localhost:8080/v1/ingest/documents/{document.rag_metadata['data'][0]['doc_id']}"
+    )
+
+    # And then re-ingested
+    _, upload_kwargs = http_client.upload.call_args_list[0]
+    url = upload_kwargs["url"]
+    file_path = upload_kwargs["filepath"]
+    metadata = upload_kwargs["metadata"]
+    field = upload_kwargs["field"]
+
+    assert url == f"http://localhost:8080/v1/ingest/files"
+    assert file_path.endswith("sharepoint_file.pdf")
+    assert field == "file"
+    ut.TestCase().assertDictEqual(
+        metadata,
+        {
+            "datasource": "documents",
+            "file_name": "sharepoint_file.pdf",
+            "self_link": r"https://ametnes.sharepoint.com/sites/nesit-test/Shared Documents/sharepoint_file.pdf",
+        },
+    )
+
+    # The document has now been updated
+    documents = session.query(Document).all()
+    assert len(documents) == 1
+    assert documents[0].store_metadata["last_modified"] == "2024-04-10 06:40:07"
+
+
+@mock.patch("nesis.api.core.document_loaders.sharepoint.ClientContext")
+def test_unsync_sharepoint_documents(
+    sharepoint_context: mock.MagicMock, cache: mock.MagicMock, session: Session
+) -> None:
+    """
+    Test deleting of sharepoint documents from the rag engine if they have been deleted from sharepoint
+    """
+    data = {
+        "name": "sharepoint documents",
+        "engine": "sharepoint",
+        "connection": {
+            "endpoint": "https://ametnes.sharepoint.com/sites/nesis-test/",
+            "client_id": "<sharepoint_app_client_id>",
+            "tenant": "<sharepoint_app_tenant_id>",
+            "thumbprint": "<sharepoint_app_cert_thumbprint>",
+            "certificate": "path_to_private_cert_keyfile",
+            "dataobjects": "Books",
+        },
+    }
+
+    document = Document(
+        base_uri="https://ametnes.sharepoint.com/sites/nesis-test/",
+        document_id="edu323-23423-23frs",
+        filename="Test_file.pdf",
+        rag_metadata={"data": [{"doc_id": str(uuid.uuid4())}]},
+        store_metadata={
+            "file_name": "Test_file.pdf",
+            "file_url": "/sites/nesit-test/Shared Documents/Test_file.pdf",
+            "etag": "edu323-23423-23frs",
+            "size": 1023,
+            "author": "author_name",
+            "last_modified": "2024-03-10 06:40:07",
+        },
+    )
+
+    session.add(document)
+    session.commit()
+
+    sp_client_context = mock.MagicMock()
+    root_folder = mock.MagicMock()
+
+    _folders = mock.MagicMock()
+
+    sharepoint_context().with_client_certificate.return_value = sp_client_context
+
+    sp_client_context.web.default_document_library.return_value.root_folder = (
+        root_folder
+    )
+
+    root_folder.folders.get_by_path.return_value = _folders
+    _folders.get_files.return_value.execute_query.return_value = []
+
+    get_file_response = mock.MagicMock()
+    sp_client_context.web.get_file_by_server_relative_url.return_value = (
+        get_file_response
+    )
+
+    response_val = mock.MagicMock()
+    type(response_val).status_code = mock.PropertyMock(return_value=404)
+
+    get_file_response.get.return_value.execute_query.side_effect = (
+        sharepoint.ClientRequestException(response=response_val)
+    )
+
+    http_client = mock.MagicMock()
+
+    documents = session.query(Document).all()
+    assert len(documents) == 1
+
+    sharepoint.fetch_documents(
+        connection=data["connection"],
+        http_client=http_client,
+        metadata={"datasource": "documents"},
+        rag_endpoint="http://localhost:8080",
+        cache_client=cache,
+    )
+
+    _, upload_kwargs = http_client.delete.call_args_list[0]
+    url = upload_kwargs["url"]
+
+    assert (
+        url
+        == f"http://localhost:8080/v1/ingest/documents/{document.rag_metadata['data'][0]['doc_id']}"
+    )
+    documents = session.query(Document).all()
+    assert len(documents) == 0
+
+
+class SharepointTest(ut.TestCase):
+
+    def setUp(self) -> None:
+        self.http_client = mock.MagicMock()
+        # self.http_client = http.HttpClient()
+        # document_management._minio_client = mock.MagicMock()
+
+        os.environ["OPENAI_API_BASE"] = "http://localhost:8080/v1"
+
+        self.config = tests.config
+        initialize_engine(self.config)
+        self.session: Session = DBSession()
+        tests.clear_database(self.session)
+
+        os.environ["OPENAI_API_KEY"] = "<open-api-key>"
+
+        os.environ["OPTIMAI_ADMIN_EMAIL"] = "<username>"
+        os.environ["OPTIMAI_ADMIN_PASSWORD"] = "<password>"
+
+        services.init_services(self.config)
+
+    def test_fetch_sharepoint_documents(self) -> None:
+        data = {
+            "name": "sharepoint documents",
+            "engine": "sharepoint",
+            "connection": {
+                "site_url": "https://ametnes.sharepoint.com/sites/nesis-test/",
+                "client_id": "<sharepoint_app_client_id>",
+                "tenant": "<sharepoint_app_tenant_id>",
+                "thumbprint": "<sharepoint_app_cert_thumbprint>",
+                "certificate": "path_to_private_cert_keyfile",
+                "dataobjects": "Books",
+            },
+        }
+
+        datasource = Datasource(
+            name=data["name"],
+            connection=data["connection"],
+            source_type=DatasourceType.SHAREPOINT,
+            status=DatasourceStatus.ONLINE,
+        )
+
+        self.session.add(datasource)
+        self.session.commit()
+
+        endpoint = (
+            "https://resource-6159823050-privategpt.dev-accounts.ametnes.net/v1/ingest"
+        )
+
+        metadata = {}
+
+        sharepoint.fetch_documents(
+            connection=data["connection"],
+            http_client=self.http_client,
+            rag_endpoint=endpoint,
+            metadata=metadata,
+            cache_client=mock.MagicMock(),
+        )

--- a/nesis/api/tests/core/document_loaders/test_sharepoint.py
+++ b/nesis/api/tests/core/document_loaders/test_sharepoint.py
@@ -31,7 +31,7 @@ def test_sync_sharepoint_documents(
         "connection": {
             "endpoint": "https://ametnes.sharepoint.com/sites/nesis-test/",
             "client_id": "<sharepoint_app_client_id>",
-            "tenant": "<sharepoint_app_tenant_id>",
+            "tenant_id": "<sharepoint_app_tenant_id>",
             "thumbprint": "<sharepoint_app_cert_thumbprint>",
             "certificate": "path_to_private_cert_keyfile",
             "dataobjects": "Books",
@@ -119,7 +119,7 @@ def test_sync_updated_sharepoint_documents(
         "connection": {
             "endpoint": "https://ametnes.sharepoint.com/sites/nesis-test/",
             "client_id": "<sharepoint_app_client_id>",
-            "tenant": "<sharepoint_app_tenant_id>",
+            "tenant_id": "<sharepoint_app_tenant_id>",
             "thumbprint": "<sharepoint_app_cert_thumbprint>",
             "certificate": "path_to_private_cert_keyfile",
             "dataobjects": "Books",
@@ -235,7 +235,7 @@ def test_unsync_sharepoint_documents(
         "connection": {
             "endpoint": "https://ametnes.sharepoint.com/sites/nesis-test/",
             "client_id": "<sharepoint_app_client_id>",
-            "tenant": "<sharepoint_app_tenant_id>",
+            "tenant_id": "<sharepoint_app_tenant_id>",
             "thumbprint": "<sharepoint_app_cert_thumbprint>",
             "certificate": "path_to_private_cert_keyfile",
             "dataobjects": "Books",
@@ -308,63 +308,3 @@ def test_unsync_sharepoint_documents(
     )
     documents = session.query(Document).all()
     assert len(documents) == 0
-
-
-class SharepointTest(ut.TestCase):
-
-    def setUp(self) -> None:
-        self.http_client = mock.MagicMock()
-        # self.http_client = http.HttpClient()
-        # document_management._minio_client = mock.MagicMock()
-
-        os.environ["OPENAI_API_BASE"] = "http://localhost:8080/v1"
-
-        self.config = tests.config
-        initialize_engine(self.config)
-        self.session: Session = DBSession()
-        tests.clear_database(self.session)
-
-        os.environ["OPENAI_API_KEY"] = "<open-api-key>"
-
-        os.environ["OPTIMAI_ADMIN_EMAIL"] = "<username>"
-        os.environ["OPTIMAI_ADMIN_PASSWORD"] = "<password>"
-
-        services.init_services(self.config)
-
-    def test_fetch_sharepoint_documents(self) -> None:
-        data = {
-            "name": "sharepoint documents",
-            "engine": "sharepoint",
-            "connection": {
-                "site_url": "https://ametnes.sharepoint.com/sites/nesis-test/",
-                "client_id": "<sharepoint_app_client_id>",
-                "tenant": "<sharepoint_app_tenant_id>",
-                "thumbprint": "<sharepoint_app_cert_thumbprint>",
-                "certificate": "path_to_private_cert_keyfile",
-                "dataobjects": "Books",
-            },
-        }
-
-        datasource = Datasource(
-            name=data["name"],
-            connection=data["connection"],
-            source_type=DatasourceType.SHAREPOINT,
-            status=DatasourceStatus.ONLINE,
-        )
-
-        self.session.add(datasource)
-        self.session.commit()
-
-        endpoint = (
-            "https://resource-6159823050-privategpt.dev-accounts.ametnes.net/v1/ingest"
-        )
-
-        metadata = {}
-
-        sharepoint.fetch_documents(
-            connection=data["connection"],
-            http_client=self.http_client,
-            rag_endpoint=endpoint,
-            metadata=metadata,
-            cache_client=mock.MagicMock(),
-        )

--- a/nesis/frontend/client/src/pages/Settings/Datasources/DatasourcesDetailPage.js
+++ b/nesis/frontend/client/src/pages/Settings/Datasources/DatasourcesDetailPage.js
@@ -574,7 +574,7 @@ function sharepointConnection() {
               type="text"
               id="tenantId"
               placeholder="tenant ID"
-              name="connection.tenant"
+              name="connection.tenant_id"
               validate={required}
             />
           </td>

--- a/nesis/frontend/client/src/pages/Settings/Datasources/DatasourcesDetailPage.js
+++ b/nesis/frontend/client/src/pages/Settings/Datasources/DatasourcesDetailPage.js
@@ -567,6 +567,20 @@ function sharepointConnection() {
         </tr>
         <tr>
           <td>
+            Tenant ID <RequiredIndicator />
+          </td>
+          <td>
+            <TextField
+              type="text"
+              id="tenantId"
+              placeholder="tenant ID"
+              name="connection.tenant"
+              validate={required}
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
             Thumbprint <RequiredIndicator />
           </td>
           <td>


### PR DESCRIPTION
Added implementation to allow ingesting of documents from sharepoint datasources. The implementation requires one to set up a client app in their ms environment with certificate crendentials that allow access to the desired sharepoint resources. 
This implementation recursively sources documents from sharepoint the list of sharepoint folders provided during the set up.

