### PR TITLE
fix(api) add api token expiry

### DIFF
--- a/nesis/api/core/config.py
+++ b/nesis/api/core/config.py
@@ -28,7 +28,9 @@ default = {
     },
     "memcache": {
         "hosts": [os.environ.get("NESIS_MEMCACHE_HOSTS", "127.0.0.1:11211")],
-        "session": {"expiry": os.environ.get("NESIS_API_MEMCACHE_SESSION_EXPIRY") or 0},
+        "session": {
+            "expiry": os.environ.get("NESIS_API_MEMCACHE_SESSION_EXPIRY") or 1800
+        },
         "cache": {
             "timeout_default": 300,
         },

--- a/nesis/api/core/config.py
+++ b/nesis/api/core/config.py
@@ -28,7 +28,7 @@ default = {
     },
     "memcache": {
         "hosts": [os.environ.get("NESIS_MEMCACHE_HOSTS", "127.0.0.1:11211")],
-        "session": {"expiry": 0},
+        "session": {"expiry": os.environ.get("NESIS_API_MEMCACHE_SESSION_EXPIRY") or 0},
         "cache": {
             "timeout_default": 300,
         },

--- a/nesis/api/core/services/app_service.py
+++ b/nesis/api/core/services/app_service.py
@@ -419,7 +419,10 @@ class AppSessionService(ServiceOperation):
         if token is None:
             raise UnauthorizedAccess("Token not supplied")
 
-        encoded_secret = base64.b64decode(token).decode("utf-8")
+        try:
+            encoded_secret = base64.b64decode(token).decode("utf-8")
+        except UnicodeDecodeError:
+            raise UnauthorizedAccess("Invalid app token supplied")
         encoded_secret_parts = encoded_secret.split(":")
         if len(encoded_secret_parts) != 2:
             raise UnauthorizedAccess("Invalid app token supplied")


### PR DESCRIPTION
This introduces expiry for the API service generated token. By setting the env variable `NESIS_API_MEMCACHE_SESSION_EXPIRY`, we are able to control the expiry of the API token. We've defaulted it to `30` minutes.

Closes #78 